### PR TITLE
fix: Remove duplicate "is" in text

### DIFF
--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -7,7 +7,7 @@ description: Overview of next-forge
 
 next-forge is a production-grade [Turborepo](https://turbo.build/repo) template for [Next.js](https://nextjs.org/) apps. It is designed to be a comprehensive starting point for new apps, providing a solid, opinionated foundation with a minimal amount of configuration.
 
-It is is a culmination of my experience building web apps over the last decade and is designed to get you to build your new SaaS app as quick as possible
+It is a culmination of my experience building web apps over the last decade and is designed to get you to build your new SaaS app as quick as possible
 
 ## Philosophy
 


### PR DESCRIPTION
- Fixed typo by removing duplicate word "is"
- Changed "it is is a" to "it is a"