### PR TITLE
Fix fetch status response error check condition

### DIFF
--- a/packages/observability/status/get.ts
+++ b/packages/observability/status/get.ts
@@ -11,7 +11,7 @@ export const getStatus = async () => {
     }
   );
 
-  if (response.ok) {
+  if (!response.ok) {
     throw new Error('Failed to fetch status');
   }
 


### PR DESCRIPTION
The previous code had an inverted condition in the fetch response check, throwing an error if the response was ok instead of if it was not ok. This commit fixes the condition to correctly throw an error when the response is not ok, ensuring errors are properly surfaced.