### PR TITLE
Update `turbo.json` to improve cache hit ratios

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -6,7 +6,6 @@
     "next": "next dev -p 3002",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
     "analyze": "ANALYZE=true pnpm build",
     "stripe": "stripe listen --forward-to localhost:3002/webhooks/stripe"
   },

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -5,7 +5,6 @@
     "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
     "analyze": "ANALYZE=true pnpm build",
     "test": "vitest run"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,6 @@
     "dev": "next dev -p 3001",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
     "analyze": "ANALYZE=true pnpm build",
     "prebuild": "content-collections build"
   },

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "bin": {
     "next-forge": "./scripts/init.js"
   },
-  "files": [
-    "scripts/init.js"
-  ],
+  "files": ["scripts/init.js"],
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,24 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build", "test"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**", "!.next/cache/**"],
+      "env": [
+        "ARCJET_KEY",
+        "BETTERSTACK_API_KEY",
+        "BETTERSTACK_URL",
+        "CLERK_SECRET_KEY",
+        "CLERK_WEBHOOK_SECRET",
+        "DATABASE_URL",
+        "FLAGS_SECRET",
+        "STRIPE_SECRET_KEY",
+        "RESEND_AUDIENCE_ID",
+        "RESEND_FROM",
+        "RESEND_TOKEN",
+        "SENTRY_AUTH_TOKEN",
+        "SENTRY_ORG",
+        "SENTRY_PROJECT",
+        "STRIPE_WEBHOOK_SECRET"
+      ]
     },
     "test": {
       "dependsOn": ["^test"]
@@ -20,21 +37,5 @@
       "persistent": true
     }
   },
-  "globalEnv": [
-    "ARCJET_KEY",
-    "BETTERSTACK_API_KEY",
-    "BETTERSTACK_URL",
-    "CLERK_SECRET_KEY",
-    "CLERK_WEBHOOK_SECRET",
-    "DATABASE_URL",
-    "FLAGS_SECRET",
-    "STRIPE_SECRET_KEY",
-    "RESEND_AUDIENCE_ID",
-    "RESEND_FROM",
-    "RESEND_TOKEN",
-    "SENTRY_AUTH_TOKEN",
-    "SENTRY_ORG",
-    "SENTRY_PROJECT",
-    "STRIPE_WEBHOOK_SECRET"
-  ]
+
 }

--- a/turbo.json
+++ b/turbo.json
@@ -36,6 +36,5 @@
       "cache": false,
       "persistent": true
     }
-  },
-
+  }
 }


### PR DESCRIPTION
When using `globalEnv`, you're much more likely to miss cache because of changes to environment variables. `globalEnv` is included in the hash for all tasks, so even tasks like `lint` who typically don't care much about environment variables will miss cache (when they probably don't need to).

By moving these variables to the `build` task (likely the only task using these environment variables), we can make sure that builds account for these variables while tasks don't.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the `"lint"` script from the `package.json` files across the `api`, `app`, and `web` applications, simplifying the available script commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->