### PR TITLE
Remove root tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,0 @@
-{
-  "extends": "@repo/typescript-config/base.json"
-}


### PR DESCRIPTION
## Description

A root tsconfig.json in a Workspace doesn't do anything if there isn't any TypeScript code in the root (which there shouldn't be). Packages set their own TypeScript settings in their own `tsconfig.json`.
