### PR TITLE
fix: add sheet title for a11y.

### DIFF
--- a/packages/design-system/components/ui/sidebar.tsx
+++ b/packages/design-system/components/ui/sidebar.tsx
@@ -10,7 +10,7 @@ import { cn } from "@repo/design-system/lib/utils"
 import { Button } from "@repo/design-system/components/ui/button"
 import { Input } from "@repo/design-system/components/ui/input"
 import { Separator } from "@repo/design-system/components/ui/separator"
-import { Sheet, SheetContent } from "@repo/design-system/components/ui/sheet"
+import { Sheet, SheetContent, SheetTitle } from "@repo/design-system/components/ui/sheet"
 import { Skeleton } from "@repo/design-system/components/ui/skeleton"
 import {
   Tooltip,
@@ -206,7 +206,7 @@ const Sidebar = React.forwardRef<
             }
             side={side}
           >
-            <SheetTitle className="sr-only"/>
+            <SheetTitle className="sr-only" />
             <div className="flex h-full w-full flex-col">{children}</div>
           </SheetContent>
         </Sheet>

--- a/packages/design-system/components/ui/sidebar.tsx
+++ b/packages/design-system/components/ui/sidebar.tsx
@@ -206,6 +206,7 @@ const Sidebar = React.forwardRef<
             }
             side={side}
           >
+            <SheetTitle className="sr-only"/>
             <div className="flex h-full w-full flex-col">{children}</div>
           </SheetContent>
         </Sheet>


### PR DESCRIPTION
## Description

Add a <SheetTitle /> component to the mobile sidebar that is only visual to screen readers.

## Related Issues

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

![CleanShot 2024-11-15 at 18 54 44@2x](https://github.com/user-attachments/assets/f3ac9b7b-b102-495b-8b89-cf8bb2060131)


## Additional Notes

I made the title screen reader only. There may be a better default. 
