### PR TITLE
fix: resolve submenu duplication issues by using index as a key

### DIFF
--- a/apps/web/app/components/header/index.tsx
+++ b/apps/web/app/components/header/index.tsx
@@ -95,10 +95,10 @@ export const Header = () => {
                             </Button>
                           </div>
                           <div className="flex h-full flex-col justify-end text-sm">
-                            {item.items?.map((subItem) => (
+                            {item.items?.map((subItem, idx) => (
                               <NavigationMenuLink
                                 href={subItem.href}
-                                key={subItem.title}
+                                key={idx}
                                 className="flex flex-row items-center justify-between rounded px-4 py-2 hover:bg-muted"
                               >
                                 <span>{subItem.title}</span>


### PR DESCRIPTION
## Description
App: `web`
Running the initial app in development mode and hovering over the **Products** link triggers an error. The issue arises from iterating over submenu links using duplicate keys. (More info on the screenshot below)
There are three potential solutions:
1. Use the second argument of the `map` method (index) as a key: I opted for this approach since the submenu items are static and not intended to be dynamically changed. This is the most straightforward and context-appropriate fix.
2. Rename the links: While this resolves the duplication, it’s misleading in this case because all links point to the same destination (Pricing). Renaming them adds unnecessary confusion.
3. Enrich the links structure by adding an `id` property. Personally, I find this unnecessary. In real-world usage, links would inherently have unique titles, so introducing an artificial id adds unnecessary overhead.

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

<img width="1512" alt="Screenshot 2024-11-23 at 1 52 17 PM" src="https://github.com/user-attachments/assets/52f5597f-92f7-4b87-880e-f1dc2fce5ddf">
