### PR TITLE
Minor: fix authjs migration secrets creation command

### DIFF
--- a/docs/authentication/authjs.mdx
+++ b/docs/authentication/authjs.mdx
@@ -28,9 +28,9 @@ pnpm add next-auth@beta --filter auth
 Auth.js requires a random value secret, used by the library to encrypt tokens and email verification hashes. In each of the relevant app directories, generate a secret with the following command:
 
 ```sh Terminal
-cd apps/app && npx auth secret
-cd apps/web && npx auth secret
-cd apps/api && npx auth secret
+cd apps/app && npx auth secret && cd -
+cd apps/web && npx auth secret && cd -
+cd apps/api && npx auth secret && cd -
 ```
 
 This will automatically add an `AUTH_SECRET` environment variable to the `.env.local` file in each directory.


### PR DESCRIPTION


## Description

If I copy and paste all the suggested commands, from the second command
I'd get the error message "no such directory" on `cd apps/web`.

## Related Issues

None

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

N/A

## Additional Notes

<!-- Add any additional information or context about the pull request here. -->
