### PR TITLE
Add Lemon Squeezy guide

### DIFF
--- a/docs/migrations/payments/lemon-squeezy.mdx
+++ b/docs/migrations/payments/lemon-squeezy.mdx
@@ -1,0 +1,91 @@
+---
+title: Switch to Lemon Squeezy
+description: How to change the default payment processor to Lemon Squeezy.
+---
+
+[Lemon Squeezy](https://www.lemonsqueezy.com) is an all-in-one platform for running your SaaS business. It handles payments, subscriptions, global tax compliance, fraud prevention, multi-currency, and more. Here's how to switch the default payment processor from Stripe to Lemon Squeezy.
+
+## 1. Swap out the required dependencies
+
+First, uninstall the existing dependencies from the Payments package...
+
+```sh Terminal
+pnpm remove stripe --filter @repo/payments
+```
+
+... and install the new dependencies...
+
+```sh Terminal
+pnpm add @lemonsqueezy/lemonsqueezy.js --filter @repo/payments
+```
+
+## 2. Update the environment variables
+
+Next, update the environment variables across the project, for example:
+
+```js apps/app/.env
+NEXT_PUBLIC_LEMON_SQUEEZY_API_KEY=""
+```
+
+Additionally, replace all instances of `STRIPE_SECRET_KEY` with `LEMON_SQUEEZY_API_KEY` in the `packages/env/index.ts` file.
+
+## 3. Update the payments client
+
+Initialize the payments client in the `packages/payments/index.ts` file with the new API key. Then, export the `lemonSqueezySetup` function from the file.
+
+```ts packages/payments/index.ts
+import { env } from '@repo/env';
+import { lemonSqueezySetup } from '@lemonsqueezy/lemonsqueezy.js';
+
+lemonSqueezySetup({
+  apiKey,
+  onError: (error) => console.error("Error!", error),
+});
+
+export * from '@lemonsqueezy/lemonsqueezy.js';
+```
+
+## 4. Update the payments webhook handler
+
+Remove the Stripe webhook handler from the API package...
+
+```sh Terminal
+rm apps/api/app/webhooks/stripe/route.ts
+```
+
+... and create a new webhook handler for Lemon Squeezy:
+
+```ts apps/api/app/webhooks/lemon-squeezy/route.ts
+import { NextResponse } from 'next/server';
+
+export const POST = async (request: Request) => {
+  return NextResponse.json({ message: 'Hello World' });
+};
+```
+
+There's quite a lot you can do with Lemon Squeezy, so check out the following resources for more information:
+
+<Card title="Webhooks Overview" icon="webhook" href="https://docs.lemonsqueezy.com/guides/developer-guide/webhooks" horizontal>
+  Learn how to handle webhooks from Lemon Squeezy
+</Card>
+
+<Card title="Signing Requests" icon="badge-check" href="https://docs.lemonsqueezy.com/help/webhooks/signing-requests" horizontal>
+  Learn how to verify webhooks from Lemon Squeezy
+</Card>
+
+
+## 5. Use Lemon Squeezy in your app
+
+Finally, use the new payments client in your app.
+
+```tsx apps/app/app/(authenticated)/page.tsx
+import { getStore } from '@repo/payments';
+
+const Page = async () => {
+  const store = await getStore(123456);
+
+  return (
+    <pre>{JSON.stringify(store, null, 2)}</pre>
+  );
+};
+```

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -176,6 +176,10 @@
       "pages": ["deployment/vercel", "deployment/netlify"]
     },
     {
+      "group": "Payments",
+      "pages": ["migrations/payments/lemon-squeezy"]
+    },
+    {
       "group": "",
       "pages": ["recipes/ai-chatbot"]
     },


### PR DESCRIPTION
This pull request includes documentation updates to guide users on switching the default payment processor from Stripe to Lemon Squeezy. The most important changes include detailed instructions on updating dependencies, environment variables, the payments client, and the webhook handler, as well as adding a new section to the documentation index.

Documentation updates:

* [`docs/migrations/payments/lemon-squeezy.mdx`](diffhunk://#diff-b56e3cad2fa52f16ad997322dbae60a9a38f8d1f14347fc76731da159049304cR1-R91): Added a new guide on how to switch the default payment processor to Lemon Squeezy, including steps for updating dependencies, environment variables, the payments client, and the webhook handler.

Index updates:

* [`docs/mint.json`](diffhunk://#diff-c91a604899dfef4b2494c317f4fd39a7f22b79986095f580399347293d534debR178-R181): Added a new "Payments" group with a link to the Lemon Squeezy migration guide.