### PR TITLE
Update Drizzle migration documentation

### DIFF
--- a/docs/migrations/database/drizzle.mdx
+++ b/docs/migrations/database/drizzle.mdx
@@ -45,7 +45,6 @@ pnpm remove @prisma/adapter-neon @prisma/client prisma --filter database
 ```sh Terminal
 pnpm add drizzle-orm --filter database
 pnpm add -D drizzle-kit --filter database
-pnpm add @neondatabase/serverless --filter database
 ```
 
 ## 2. Update the database connection code

--- a/docs/migrations/database/drizzle.mdx
+++ b/docs/migrations/database/drizzle.mdx
@@ -45,6 +45,7 @@ pnpm remove @prisma/adapter-neon @prisma/client prisma --filter database
 ```sh Terminal
 pnpm add drizzle-orm --filter database
 pnpm add -D drizzle-kit --filter database
+pnpm add @neondatabase/serverless --filter database
 ```
 
 ## 2. Update the database connection code
@@ -75,7 +76,7 @@ export default defineConfig({
   out: './',
   dialect: 'postgresql',
   dbCredentials: {
-    url: databaseUrl,
+    url: env.DATABASE_URL,
   },
 });
 ```
@@ -117,4 +118,16 @@ You can also delete the now unused Prisma Studio app located at `apps/studio`:
 
 ```sh Terminal
 rm -fr apps/studio
+```
+
+## 7. Update the migration script in the root `package.json`
+
+Change the migration script in the root `package.json` from Prisma to Drizzle. Update the `migrate` script to use Drizzle commands:
+
+```json
+"scripts": {
+  "db:migrate": "cd packages/database && npx drizzle-kit migrate"
+  "db:generate": "cd packages/database && npx drizzle-kit generate"
+  "db:pull": "cd packages/database && npx drizzle-kit pull"
+}
 ```

--- a/docs/migrations/database/drizzle.mdx
+++ b/docs/migrations/database/drizzle.mdx
@@ -55,6 +55,7 @@ Delete everything in `@repo/database/index.ts` and replace it with the following
 import 'server-only';
 
 import { drizzle } from 'drizzle-orm/neon-http';
+import { neon } from '@neondatabase/serverless';
 import { env } from '@repo/env';
 
 const client = neon(env.DATABASE_URL);


### PR DESCRIPTION
Fixes #340

Update the Drizzle migration documentation to include missing package and environment configuration steps.

* Add a step to install `@neondatabase/serverless` package in the `docs/migrations/database/drizzle.mdx` file.
* Change the `databaseUrl` to the `DATABASE_URL` environment variable in the `drizzle.config.ts` file.
* Add a step to update the migration script in the root `package.json` from Prisma to Drizzle in the `docs/migrations/database/drizzle.mdx` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/haydenbleasel/next-forge/pull/341?shareId=29a8caf4-b759-46d3-aab2-7aae3f5811da).