### PR TITLE
Replace next-secure-headers with Nosecone for security headers

### DIFF
--- a/apps/app/middleware.ts
+++ b/apps/app/middleware.ts
@@ -1,21 +1,5 @@
 import { authMiddleware } from '@repo/auth/middleware';
-import { env } from '@repo/env';
-import {
-  noseconeDefaults,
-  noseconeMiddleware,
-  withVercelToolbar,
-  type NoseconeOptions
-} from '@repo/security/middleware';
-
-// Nosecone security headers configuration
-// https://docs.arcjet.com/nosecone/quick-start
-const noseconeOptions: NoseconeOptions = {
-  ...noseconeDefaults,
-  contentSecurityPolicy: false,
-}
-
-// Add Vercel toolbar compatible options if we're in a preview environment
-const noseconeConfig = (env.NODE_ENV === 'development' && env.FLAGS_SECRET) ? withVercelToolbar(noseconeOptions) : noseconeOptions;
+import { noseconeConfig, noseconeMiddleware } from '@repo/security/middleware';
 
 const securityHeaders = noseconeMiddleware(noseconeConfig);
 
@@ -31,4 +15,3 @@ export const config = {
     '/(api|trpc)(.*)',
   ],
 };
-

--- a/apps/app/middleware.ts
+++ b/apps/app/middleware.ts
@@ -11,45 +11,7 @@ import {
 // https://docs.arcjet.com/nosecone/quick-start
 const noseconeOptions: NoseconeOptions = {
   ...noseconeDefaults,
-  contentSecurityPolicy: {
-    ...noseconeDefaults.contentSecurityPolicy,
-    directives: {
-      ...noseconeDefaults.contentSecurityPolicy.directives,
-      scriptSrc: [
-        // We have to use unsafe-inline because next-themes and Vercel Analytics
-        // do not support nonce
-        // https://github.com/pacocoursey/next-themes/issues/106
-        // https://github.com/vercel/analytics/issues/122
-        //...noseconeDefaults.contentSecurityPolicy.directives.scriptSrc,
-        "'self'",
-        "'unsafe-inline'",
-        "https://www.googletagmanager.com",
-        "https://*.clerk.accounts.dev",
-        "https://va.vercel-scripts.com",
-      ],
-      connectSrc: [
-        ...noseconeDefaults.contentSecurityPolicy.directives.connectSrc,
-        "https://*.clerk.accounts.dev",
-        "https://*.google-analytics.com",
-        "https://clerk-telemetry.com",
-      ],
-      workerSrc: [
-        ...noseconeDefaults.contentSecurityPolicy.directives.workerSrc,
-        "blob:",
-        "https://*.clerk.accounts.dev"
-      ],
-      imgSrc: [
-        ...noseconeDefaults.contentSecurityPolicy.directives.imgSrc,
-        "https://img.clerk.com"
-      ],
-      objectSrc: [
-        ...noseconeDefaults.contentSecurityPolicy.directives.objectSrc,
-      ],
-      // We only set this in production because the server may be started
-      // without HTTPS
-      upgradeInsecureRequests: process.env.NODE_ENV === "production",
-    },
-  },
+  contentSecurityPolicy: false,
 }
 
 // Add Vercel toolbar compatible options if we're in a preview environment

--- a/apps/app/middleware.ts
+++ b/apps/app/middleware.ts
@@ -1,6 +1,65 @@
 import { authMiddleware } from '@repo/auth/middleware';
+import { env } from '@repo/env';
+import {
+  noseconeDefaults,
+  noseconeMiddleware,
+  withVercelToolbar,
+  type NoseconeOptions
+} from '@repo/security/middleware';
 
-export default authMiddleware();
+// Nosecone security headers configuration
+// https://docs.arcjet.com/nosecone/quick-start
+const noseconeOptions: NoseconeOptions = {
+  ...noseconeDefaults,
+  contentSecurityPolicy: {
+    ...noseconeDefaults.contentSecurityPolicy,
+    directives: {
+      ...noseconeDefaults.contentSecurityPolicy.directives,
+      scriptSrc: [
+        // We have to use unsafe-inline because next-themes and Vercel Analytics
+        // do not support nonce
+        // https://github.com/pacocoursey/next-themes/issues/106
+        // https://github.com/vercel/analytics/issues/122
+        //...noseconeDefaults.contentSecurityPolicy.directives.scriptSrc,
+        "'self'",
+        "'unsafe-inline'",
+        "https://www.googletagmanager.com",
+        "https://*.clerk.accounts.dev",
+        "https://va.vercel-scripts.com",
+      ],
+      connectSrc: [
+        ...noseconeDefaults.contentSecurityPolicy.directives.connectSrc,
+        "https://*.clerk.accounts.dev",
+        "https://*.google-analytics.com",
+        "https://clerk-telemetry.com",
+      ],
+      workerSrc: [
+        ...noseconeDefaults.contentSecurityPolicy.directives.workerSrc,
+        "blob:",
+        "https://*.clerk.accounts.dev"
+      ],
+      imgSrc: [
+        ...noseconeDefaults.contentSecurityPolicy.directives.imgSrc,
+        "https://img.clerk.com"
+      ],
+      objectSrc: [
+        ...noseconeDefaults.contentSecurityPolicy.directives.objectSrc,
+      ],
+      // We only set this in production because the server may be started
+      // without HTTPS
+      upgradeInsecureRequests: process.env.NODE_ENV === "production",
+    },
+  },
+}
+
+// Add Vercel toolbar compatible options if we're in a preview environment
+const noseconeConfig = (env.NODE_ENV === 'development' && env.FLAGS_SECRET) ? withVercelToolbar(noseconeOptions) : noseconeOptions;
+
+const securityHeaders = noseconeMiddleware(noseconeConfig);
+
+export default authMiddleware(() => {
+  return securityHeaders();
+});
 
 export const config = {
   matcher: [
@@ -10,3 +69,4 @@ export const config = {
     '/(api|trpc)(.*)',
   ],
 };
+

--- a/apps/app/middleware.ts
+++ b/apps/app/middleware.ts
@@ -3,9 +3,7 @@ import { noseconeConfig, noseconeMiddleware } from '@repo/security/middleware';
 
 const securityHeaders = noseconeMiddleware(noseconeConfig);
 
-export default authMiddleware(() => {
-  return securityHeaders();
-});
+export default authMiddleware(() => securityHeaders());
 
 export const config = {
   matcher: [

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@prisma/client": "6.0.1",
-    "@repo/auth": "workspace:*",
     "@repo/analytics": "workspace:*",
+    "@repo/auth": "workspace:*",
     "@repo/collaboration": "workspace:*",
     "@repo/database": "workspace:*",
     "@repo/design-system": "workspace:*",

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -2,6 +2,7 @@ import { authMiddleware } from '@repo/auth/middleware';
 import { env } from '@repo/env';
 import { parseError } from '@repo/observability/error';
 import { secure } from '@repo/security';
+import { noseconeConfig, noseconeMiddleware } from '@repo/security/middleware';
 import { NextResponse } from 'next/server';
 
 export const config = {
@@ -10,9 +11,11 @@ export const config = {
   matcher: ['/((?!_next/static|_next/image|ingest|favicon.ico).*)'],
 };
 
+const securityHeaders = noseconeMiddleware(noseconeConfig);
+
 export default authMiddleware(async (_auth, request) => {
   if (!env.ARCJET_KEY) {
-    return NextResponse.next();
+    return securityHeaders();
   }
 
   try {
@@ -26,7 +29,7 @@ export default authMiddleware(async (_auth, request) => {
       request
     );
 
-    return NextResponse.next();
+    return securityHeaders();
   } catch (error) {
     const message = parseError(error);
 

--- a/docs/features/security/headers.mdx
+++ b/docs/features/security/headers.mdx
@@ -32,9 +32,9 @@ They are then attached to the response within the middleware in `apps/app/middle
 
 ## Content Security Policy (CSP)
 
-The CSP header is not set by default because it requires specific configuration based on the Next Forge features you have enabled. We hope to change this in the future once [#332](https://github.com/haydenbleasel/next-forge/pull/332) is resolved.
+The CSP header is not set by default because it requires specific configuration based on the next-forge features you have enabled.
 
-In the meantime, you can set the CSP header using the Nosecone configuration. For example, the following CSP configuration will work with the default Next Forge features:
+In the meantime, you can set the CSP header using the Nosecone configuration. For example, the following CSP configuration will work with the default next-forge features:
 
 ```ts
 import type { NoseconeOptions } from '@nosecone/next';

--- a/docs/features/security/headers.mdx
+++ b/docs/features/security/headers.mdx
@@ -3,25 +3,84 @@ title: Security Headers
 description: Security headers used to protect your application.
 ---
 
-next-forge uses [next-secure-headers](https://github.com/jagaapple/next-secure-headers) to set HTTP response headers related to security.
+next-forge uses [Nosecone](https://docs.arcjet.com/nosecone/quick-start) to set HTTP response headers related to security.
 
 ## Configuration
 
 Here are the headers we have enabled:
 
-| Property | Header | Description | Value |
-| --- | --- | --- | --- |
-| `forceHTTPSRedirect` | `Strict-Transport-Security` | Prevents browsers from connecting to your site over HTTP. | `[true, { maxAge: 63_072_000, includeSubDomains: true, preload: true }]` |
-| `frameGuard` | `X-Frame-Options` | Prevents browsers from rendering your site in an iframe. | `deny` |
-| `noopen` | `X-Download-Options` | Prevents browsers from automatically opening downloaded files in the same origin as the page. | `noopen` |
-| `nosniff` | `X-Content-Type-Options` | Prevents browsers from MIME-sniffing a response away from the declared content type. | `nosniff` |
-| `xssProtection` | `X-XSS-Protection` | Prevents browsers from executing inline scripts if a cross-site scripting attack is detected. | `sanitize` |
-| `contentSecurityPolicy` | `Content-Security-Policy` | Sets a policy to prevent a wide range of different types of attacks, including Cross Site Scripting (XSS) and data injection attacks. | `false` |
-| `expectCT` | `Expect-CT` | Enables a mechanism to mitigate the risk of fraudulent certificates being used in connections to your site. | `false` |
-| `referrerPolicy` | `Referrer-Policy` | Controls how much of the full URL is included in the `Referer` header. | `false` |
+- `Cross-Origin-Embedder-Policy` (COEP)
+- `Cross-Origin-Opener-Policy`
+- `Cross-Origin-Resource-Policy`
+- `Origin-Agent-Cluster`
+- `Referrer-Policy`
+- `Strict-Transport-Security` (HSTS)
+- `X-Content-Type-Options`
+- `X-DNS-Prefetch-Control`
+- `X-Download-Options`
+- `X-Frame-Options`
+- `X-Permitted-Cross-Domain-Policies`
+- `X-XSS-Protection`
 
-<Tip>The `forceHTTPSRedirect` property has been customized from the default to include subdomains and preload the HSTS policy. This should allow you to submit your site at [hstspreload.org](https://hstspreload.org/) without any issues.</Tip>
+See the [Nosecone reference](https://docs.arcjet.com/nosecone/reference) for details on each header and configuration options.
 
 ## Usage
 
-The headers are enabled by default when using the `next-config` package. If you are customizing your `next.config.ts` file, you can extend the headers manually.
+Recommended headers are set by default and configured in `@repo/security/middleware`. Changing the configuration here will affect all apps.
+
+They are then attached to the response within the middleware in `apps/app/middleware` and `apps/web/middleware.ts`. Adjusting the configuration in these files will only affect the specific app.
+
+## Content Security Policy (CSP)
+
+The CSP header is not set by default because it requires specific configuration based on the Next Forge features you have enabled. We hope to change this in the future once [#332](https://github.com/haydenbleasel/next-forge/pull/332) is resolved.
+
+In the meantime, you can set the CSP header using the Nosecone configuration. For example, the following CSP configuration will work with the default Next Forge features:
+
+```ts
+import type { NoseconeOptions } from '@nosecone/next';
+import { defaults as noseconeDefaults } from '@nosecone/next';
+
+const noseconeOptions: NoseconeOptions = {
+  ...noseconeDefaults,
+  contentSecurityPolicy: {
+    ...noseconeDefaults.contentSecurityPolicy,
+    directives: {
+      ...noseconeDefaults.contentSecurityPolicy.directives,
+      scriptSrc: [
+        // We have to use unsafe-inline because next-themes and Vercel Analytics
+        // do not support nonce
+        // https://github.com/pacocoursey/next-themes/issues/106
+        // https://github.com/vercel/analytics/issues/122
+        //...noseconeDefaults.contentSecurityPolicy.directives.scriptSrc,
+        "'self'",
+        "'unsafe-inline'",
+        "https://www.googletagmanager.com",
+        "https://*.clerk.accounts.dev",
+        "https://va.vercel-scripts.com",
+      ],
+      connectSrc: [
+        ...noseconeDefaults.contentSecurityPolicy.directives.connectSrc,
+        "https://*.clerk.accounts.dev",
+        "https://*.google-analytics.com",
+        "https://clerk-telemetry.com",
+      ],
+      workerSrc: [
+        ...noseconeDefaults.contentSecurityPolicy.directives.workerSrc,
+        "blob:",
+        "https://*.clerk.accounts.dev"
+      ],
+      imgSrc: [
+        ...noseconeDefaults.contentSecurityPolicy.directives.imgSrc,
+        "https://img.clerk.com"
+      ],
+      objectSrc: [
+        ...noseconeDefaults.contentSecurityPolicy.directives.objectSrc,
+      ],
+      // We only set this in production because the server may be started
+      // without HTTPS
+      upgradeInsecureRequests: process.env.NODE_ENV === "production",
+    },
+  },
+}
+```
+

--- a/docs/features/security/headers.mdx
+++ b/docs/features/security/headers.mdx
@@ -3,6 +3,28 @@ title: Security Headers
 description: Security headers used to protect your application.
 ---
 
+import { Authors } from '/snippets/authors.mdx';
+
+<Authors data={[{
+  user: {
+    name: 'Hayden Bleasel',
+    id: 'haydenbleasel',
+  },
+  company: {
+    name: 'next-forge',
+    id: 'next-forge',
+  },
+}, {
+  user: {
+    name: 'David Mytton',
+    id: 'davidmytton',
+  },
+  company: {
+    name: 'Arcjet',
+    id: 'arcjet',
+  },
+}]} />
+
 next-forge uses [Nosecone](https://docs.arcjet.com/nosecone/quick-start) to set HTTP response headers related to security.
 
 ## Configuration

--- a/packages/next-config/index.ts
+++ b/packages/next-config/index.ts
@@ -6,7 +6,6 @@ import { env } from '@repo/env';
 import { withSentryConfig } from '@sentry/nextjs';
 import withVercelToolbar from '@vercel/toolbar/plugins/next';
 import type { NextConfig } from 'next';
-import { createSecureHeaders } from 'next-secure-headers';
 
 const otelRegex = /@opentelemetry\/instrumentation/;
 
@@ -35,22 +34,6 @@ const baseConfig: NextConfig = {
       {
         source: '/ingest/decide',
         destination: 'https://us.i.posthog.com/decide',
-      },
-    ];
-  },
-
-  // biome-ignore lint/suspicious/useAwait: headers is async
-  async headers() {
-    return [
-      {
-        source: '/(.*)',
-        headers: createSecureHeaders({
-          // HSTS Preload: https://hstspreload.org/
-          forceHTTPSRedirect: [
-            true,
-            { maxAge: 63_072_000, includeSubDomains: true, preload: true },
-          ],
-        }),
       },
     ];
   },

--- a/packages/next-config/package.json
+++ b/packages/next-config/package.json
@@ -18,7 +18,6 @@
     "@next/bundle-analyzer": "^15.1.0",
     "@prisma/nextjs-monorepo-workaround-plugin": "^6.0.1",
     "@sentry/nextjs": "^8.43.0",
-    "@vercel/toolbar": "^0.1.28",
-    "next-secure-headers": "^2.2.0"
+    "@vercel/toolbar": "^0.1.28"
   }
 }

--- a/packages/security/middleware.ts
+++ b/packages/security/middleware.ts
@@ -1,0 +1,1 @@
+export { createMiddleware as noseconeMiddleware, type NoseconeOptions, defaults as noseconeDefaults, withVercelToolbar } from "@nosecone/next";

--- a/packages/security/middleware.ts
+++ b/packages/security/middleware.ts
@@ -1,1 +1,23 @@
-export { createMiddleware as noseconeMiddleware, type NoseconeOptions, defaults as noseconeDefaults, withVercelToolbar } from "@nosecone/next";
+import {
+  type NoseconeOptions,
+  defaults,
+  withVercelToolbar,
+} from '@nosecone/next';
+import { env } from '@repo/env';
+export { createMiddleware as noseconeMiddleware } from '@nosecone/next';
+
+// Nosecone security headers configuration
+// https://docs.arcjet.com/nosecone/quick-start
+const noseconeOptions: NoseconeOptions = {
+  ...defaults,
+  // Content Security Policy (CSP) is disabled by default because the values
+  // depend on which Next Forge features are enabled. See
+  // https://docs.next-forge.com/features/security/headers for guidance on how
+  // to configure it.
+  contentSecurityPolicy: false,
+};
+
+export const noseconeConfig: NoseconeOptions =
+  env.NODE_ENV === 'development' && env.FLAGS_SECRET
+    ? withVercelToolbar(noseconeOptions)
+    : noseconeOptions;

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -2,6 +2,7 @@
   "name": "@repo/security",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "format": "biome lint --write .",
@@ -10,6 +11,7 @@
   },
   "dependencies": {
     "@arcjet/next": "1.0.0-alpha.34",
+    "@nosecone/next": "1.0.0-alpha.34",
     "@repo/env": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -918,9 +918,6 @@ importers:
       '@vercel/toolbar':
         specifier: ^0.1.28
         version: 0.1.28(next@15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)(vite@5.4.10(@types/node@22.10.1)(terser@5.31.0))
-      next-secure-headers:
-        specifier: ^2.2.0
-        version: 2.2.0
     devDependencies:
       '@repo/env':
         specifier: workspace:*
@@ -987,6 +984,9 @@ importers:
       '@arcjet/next':
         specifier: 1.0.0-alpha.34
         version: 1.0.0-alpha.34(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.6.1(@bufbuild/protobuf@1.10.0))(next@15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
+      '@nosecone/next':
+        specifier: 1.0.0-alpha.34
+        version: 1.0.0-alpha.34(next@15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))
       '@repo/env':
         specifier: workspace:*
         version: link:../env
@@ -2843,6 +2843,12 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@nosecone/next@1.0.0-alpha.34':
+    resolution: {integrity: sha512-4KXgjR580QTsdbM/F9WoLR/AQxJD48na27XnS9De5LIFBemDZ5ObC6L901WrBF3EJGz1M0E9AFQ0nKGUh+ascQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      next: '>=14'
 
   '@octokit/auth-token@2.5.0':
     resolution: {integrity: sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==}
@@ -7813,10 +7819,6 @@ packages:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
 
-  next-secure-headers@2.2.0:
-    resolution: {integrity: sha512-C7OfZ9JdSJyYMz2ZBMI/WwNbt0qNjlFWX9afUp8nEUzbz6ez3JbeopdyxSZJZJAzVLIAfyk6n73rFpd4e22jRg==}
-    engines: {node: '>=10.0.0'}
-
   next-themes@0.4.4:
     resolution: {integrity: sha512-LDQ2qIOJF0VnuVrrMSMLrWGjRMkq+0mpgl6e0juCLqdJ+oo8Q84JRWT6Wh11VDQKkMMe+dVzDKLWs5n87T+PkQ==}
     peerDependencies:
@@ -7956,6 +7958,10 @@ packages:
   normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
+
+  nosecone@1.0.0-alpha.34:
+    resolution: {integrity: sha512-GPqypMOeGXjZXHS+I9jTBFB12GNlAmC21LRRhAKuc4v2beMDzW/ChYSQ8sMSr0f7/Ov4ffQJH0i84iAny5Y5fg==}
+    engines: {node: '>=18'}
 
   npm-run-path@2.0.2:
     resolution: {integrity: sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==}
@@ -12124,6 +12130,11 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@nosecone/next@1.0.0-alpha.34(next@15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))':
+    dependencies:
+      next: 15.1.0(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      nosecone: 1.0.0-alpha.34
 
   '@octokit/auth-token@2.5.0':
     dependencies:
@@ -18170,8 +18181,6 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next-secure-headers@2.2.0: {}
-
   next-themes@0.4.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       react: 19.0.0
@@ -18366,6 +18375,8 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-range@0.1.2: {}
+
+  nosecone@1.0.0-alpha.34: {}
 
   npm-run-path@2.0.2:
     dependencies:


### PR DESCRIPTION
## Description

next-secure-headers hasn't been updated for 3 years and is setting obsolete security headers. We just released [Nosecone](https://docs.arcjet.com/nosecone/quick-start) which is an open source library for configuring security headers like CSP and HSTS on Next.js and other frameworks.

As discussed in the PR, CSP is not set by default. We can revisit when https://github.com/haydenbleasel/next-forge/pull/332 is done. There is a working example config in the docs.

### next-secure-headers vs Nosecone

Loading http://localhost:3000/sign-in sets the following headers:

```
Cache-Control: no-store, must-revalidate
Connection: keep-alive
Content-Encoding: gzip
Content-Type: text/html; charset=utf-8
Date: Tue, 10 Dec 2024 18:48:01 GMT
Keep-Alive: timeout=5
Link: </_next/static/media/GeistMono_Variable.p.0ce97b8a.woff2>; rel=preload; as="font"; crossorigin=""; type="font/woff2", </_next/static/media/Geist_Variable-s.p.781b491f.woff2>; rel=preload; as="font"; crossorigin=""; type="font/woff2"
Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
Transfer-Encoding: chunked
Vary: RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding
x-clerk-auth-reason: session-token-and-uat-missing
x-clerk-auth-status: signed-out
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: deny
x-middleware-rewrite: /sign-in?redirect_url=http%3A%2F%2Flocalhost%3A3000%2F
X-Powered-By: Next.js
X-XSS-Protection: 1
```

With Nosecone, the same page sets the following:

```
Cache-Control: no-store, must-revalidate
Connection: keep-alive
Content-Encoding: gzip
Content-Type: text/html; charset=utf-8
Cross-Origin-Embedder-Policy: require-corp
Cross-Origin-Opener-Policy: same-origin
Cross-Origin-Resource-Policy: same-origin
Date: Tue, 10 Dec 2024 18:49:46 GMT
Keep-Alive: timeout=5
Link: </_next/static/media/GeistMono_Variable.p.0ce97b8a.woff2>; rel=preload; as="font"; crossorigin=""; type="font/woff2", </_next/static/media/Geist_Variable-s.p.781b491f.woff2>; rel=preload; as="font"; crossorigin=""; type="font/woff2"
origin-agent-cluster: ?1
Referrer-Policy: no-referrer
Strict-Transport-Security: max-age=31536000; includeSubDomains
Transfer-Encoding: chunked
Vary: RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding
x-clerk-auth-reason: session-token-and-uat-missing
x-clerk-auth-status: signed-out
X-Content-Type-Options: nosniff
X-DNS-Prefetch-Control: off
x-download-options: noopen
X-Frame-Options: SAMEORIGIN
x-middleware-rewrite: /sign-in?redirect_url=http%3A%2F%2Flocalhost%3A3000%2F
x-permitted-cross-domain-policies: none
X-Powered-By: Next.js
X-XSS-Protection: 0
```

The headers removed are:

- `Expect-CT` = [deprecated](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT)
- `X-XSS-Protection` = deprecated, but set to `0` because other values are a [security vulnerability](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection#security_considerations)

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.