### PR TITLE
Change Cron to daily to allow vercel hobby projects

### DIFF
--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/cron/keep-alive",
-      "schedule": "*/10 * * * *"
+      "schedule": "0 1 * * *"
     }
   ]
 }

--- a/docs/features/cron.mdx
+++ b/docs/features/cron.mdx
@@ -34,7 +34,7 @@ After you write your serverless function, you can schedule it by amending the `v
   "crons": [
     {
       "path": "/cron/keep-alive",
-      "schedule": "*/10 * * * *"
+      "schedule": "0 1 * * *"
     }
   ]
 }


### PR DESCRIPTION


## Description

With current setup, "vercel link" returns "Error: Hobby accounts are limited to daily cron jobs. This cron expression (*/10 * * * *) would run more than once per day. Upgrade to pro to unlock all Cron Jobs features on Vercel."

`https://crontab.guru/#0_1_*_*_*` = “At 01:00.”

## Related Issues

None

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

<!-- Add any additional information or context about the pull request here. -->
