### PR TITLE
Fix: cron jobs must use GET on Vercel

### DIFF
--- a/apps/api/app/cron/keep-alive/route.ts
+++ b/apps/api/app/cron/keep-alive/route.ts
@@ -1,6 +1,6 @@
 import { database } from '@repo/database';
 
-export const POST = async () => {
+export const GET = async () => {
   const newPage = await database.page.create({
     data: {
       name: 'cron-temp',

--- a/docs/packages/cron.mdx
+++ b/docs/packages/cron.mdx
@@ -18,7 +18,8 @@ You can add new functions by creating the relevant `route.ts` files in the `apps
 ```ts apps/api/app/cron/[your-function]/route.ts
 import { database } from '@repo/database';
 
-export const POST = async () => {
+// Must use GET for Vercel cron jobs
+export const GET = async () => {
   // Do stuff
 
   return new Response('OK', { status: 200 });
@@ -40,10 +41,18 @@ After you write your serverless function, you can schedule it by amending the `v
 }
 ```
 
+## How Vercel triggers cron jobs
+
+To trigger a cron job, Vercel makes an HTTP GET request to your project's production deployment URL, using the path provided in your project's vercel.json file. For example, Vercel might make a request to:
+
+```
+https://*.vercel.app/cron/keep-alive
+```
+
 ## Triggering functions manually
 
 Should you need to trigger a cron job manually, you can either do so in the Vercel dashboard or just hit the endpoint with a standard HTTP request. For example:
 
 ```sh Terminal
-curl -X POST http://localhot:3002/cron/keep-alive
+curl -X GET http://localhost:3002/cron/keep-alive
 ```


### PR DESCRIPTION
## Description

Vercel makes an HTTP GET request, so defining the cron jobs as POST doesn't work when hosted on Vercel.

https://vercel.com/docs/cron-jobs#how-cron-jobs-work

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.
