### PR TITLE
Imporve document for ESLint configuration

### DIFF
--- a/docs/migrations/formatting/eslint.mdx
+++ b/docs/migrations/formatting/eslint.mdx
@@ -43,9 +43,9 @@ pnpm add -w -D eslint eslint-plugin-next eslint-plugin-react eslint-plugin-react
 
 ## 2. Configure ESLint
 
-Delete the existing `biome.json` file in the root of the project, and create a new `eslint.config.js` file:
+Delete the existing `biome.json` file in the root of the project, and create a new `eslint.config.mjs` file:
 
-```js eslint.config.js
+```js eslint.config.mjs
 import react from 'eslint-plugin-react';
 import next from '@next/eslint-plugin-next';
 import hooks from 'eslint-plugin-react-hooks';

--- a/docs/migrations/formatting/eslint.mdx
+++ b/docs/migrations/formatting/eslint.mdx
@@ -38,7 +38,7 @@ pnpm remove -w @biomejs/biome ultracite
 ...and install the new ones:
 
 ```sh Terminal
-pnpm add -w -D eslint eslint-plugin-next eslint-plugin-react eslint-plugin-react-hooks
+pnpm add -w -D eslint eslint-plugin-next eslint-plugin-react eslint-plugin-react-hooks typescript-eslint
 ```
 
 ## 2. Configure ESLint
@@ -46,22 +46,28 @@ pnpm add -w -D eslint eslint-plugin-next eslint-plugin-react eslint-plugin-react
 Delete the existing `biome.json` file in the root of the project, and create a new `eslint.config.js` file:
 
 ```js eslint.config.js
-const react = require('eslint-plugin-react');
-const next = require('eslint-plugin-next');
+import react from 'eslint-plugin-react';
+import next from '@next/eslint-plugin-next';
+import hooks from 'eslint-plugin-react-hooks';
+import ts from 'typescript-eslint'
 
 export default [
+  ...ts.configs.recommended,
   {
+    ignores: ['**/.next'],
+  },
+  { 
     files: ['**/*.ts', '**/*.tsx'],
     plugins: {
-      react: reactPlugin,
-      'react-hooks': hooksPlugin,
-      '@next/next': nextPlugin,
+      react: react,
+      'react-hooks': hooks,
+      '@next/next': next,
     },
     rules: {
-      ...reactPlugin.configs['jsx-runtime'].rules,
-      ...hooksPlugin.configs.recommended.rules,
-      ...nextPlugin.configs.recommended.rules,
-      ...nextPlugin.configs['core-web-vitals'].rules,
+      ...react.configs['jsx-runtime'].rules,
+      ...hooks.configs.recommended.rules,
+      ...next.configs.recommended.rules,
+      ...next.configs['core-web-vitals'].rules,
       '@next/next/no-img-element': 'error',
     },
   },


### PR DESCRIPTION
I noticed eslint-plugin-next is an empty package, but next.js is @next/eslint-plugin-next. 

| eslint-plugin-next                                           | @next/eslint-plugin-next                                     |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| <img width="505" alt="image" src="https://github.com/user-attachments/assets/0457fcc2-42e6-48b5-a81c-25d1871f9c0d" /> | <img width="466" alt="image" src="https://github.com/user-attachments/assets/1f4b7441-0c90-452e-95e3-98ae0eeb639a" /> |

