### PR TITLE
add basehub to turbo.json's build outputs, plus reorder toolbar

### DIFF
--- a/apps/web/app/blog/layout.tsx
+++ b/apps/web/app/blog/layout.tsx
@@ -1,15 +1,9 @@
-import { Toolbar } from '@repo/cms/components/toolbar';
 import type { ReactNode } from 'react';
 
 type BlogLayoutProps = {
   children: ReactNode;
 };
 
-const BlogLayout = ({ children }: BlogLayoutProps) => (
-  <>
-    {children}
-    <Toolbar />
-  </>
-);
+const BlogLayout = ({ children }: BlogLayoutProps) => <>{children}</>;
 
 export default BlogLayout;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -9,6 +9,7 @@ import { Toolbar } from '@repo/feature-flags/components/toolbar';
 import type { ReactNode } from 'react';
 import { Footer } from './components/footer';
 import { Header } from './components/header';
+import { Toolbar as CMSToolbar } from '@repo/cms/components/toolbar';
 
 type RootLayoutProperties = {
   readonly children: ReactNode;
@@ -33,6 +34,7 @@ const RootLayout = ({ children }: RootLayoutProperties) => (
         </Feed>
       </DesignSystemProvider>
       <Toolbar />
+      <CMSToolbar />
     </body>
   </html>
 );

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build", "test"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**", "!.next/cache/**", ".basehub/**"]
     },
     "test": {
       "dependsOn": ["^test"]


### PR DESCRIPTION
## Description

Adds `".basehub/**"` to `turbo.json`'s build outputs so that turborepo knows when basehub's schema changed. Also added <Toolbar /> in the root layout so that automatic on-demand revalidation works as expected.

## Related Issues

Closes #<issue_number>

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests that prove my fix is effective or my feature works.
- [ ] New and existing tests pass locally with my changes.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

<!-- Add any additional information or context about the pull request here. -->
