### PR TITLE
Enhance CLI command - Update  

### DIFF
--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -8,7 +8,23 @@ description: Built-in helpers to help you keep your project up to date.
 As next-forge evolves, you may want to stay up to date with the latest changes. This can be difficult to do manually, so we've created a script to help you.
 
 ```sh Terminal
-npx next-forge@latest update --from 2.18.30 --to 2.18.31
+npx next-forge@latest update
+```
+
+Select a version to update to:
+
+```
+┌  Let's update your next-forge project!
+│
+●  Current version: v3.2.10
+│
+◆  Select a version to update to:
+│  ● v3.2.15
+│  ○ v3.2.14
+│  ○ v3.2.13
+│  ○ v3.2.12
+│  ○ v3.2.11
+└
 ```
 
 This will clone the latest version of next-forge into a temporary directory, apply the updates, and then copy the files over to your project. From here, you can commit the changes and push them to your repository.

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -8,10 +8,10 @@ description: Built-in helpers to help you keep your project up to date.
 As next-forge evolves, you may want to stay up to date with the latest changes. This can be difficult to do manually, so we've created a script to help you.
 
 ```sh Terminal
-npx next-forge update
+npx next-forge@latest update
 ```
 
-Select a version to update to:
+This will run our update script, which will guide you through the process of updating your project.
 
 ```
 ┌  Let's update your next-forge project!

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -8,7 +8,7 @@ description: Built-in helpers to help you keep your project up to date.
 As next-forge evolves, you may want to stay up to date with the latest changes. This can be difficult to do manually, so we've created a script to help you.
 
 ```sh Terminal
-npx next-forge@latest update
+npx next-forge update
 ```
 
 Select a version to update to:
@@ -16,7 +16,6 @@ Select a version to update to:
 ```
 ┌  Let's update your next-forge project!
 │
-●  Current version: v3.2.10
 │
 ◆  Select a version to update to:
 │  ● v3.2.15

--- a/scripts/initialize.ts
+++ b/scripts/initialize.ts
@@ -171,7 +171,7 @@ const getName = async () => {
   const value = await text({
     message: 'What is your project named?',
     placeholder: 'my-app',
-    validate(value) {
+    validate(value: string) {
       if (value.length === 0) {
         return 'Please enter a project name.';
       }

--- a/scripts/update.ts
+++ b/scripts/update.ts
@@ -84,6 +84,7 @@ const selectVersion = async (
     message: 'Select a version to update to:',
     options: availableVersions.map((v) => ({ value: v, label: `v${v}` })),
     initialValue,
+    maxItems: 10,
   });
 
   if (isCancel(version)) {

--- a/scripts/update.ts
+++ b/scripts/update.ts
@@ -56,8 +56,11 @@ const updateFiles = async (files: string[]) => {
 const deleteTemporaryDirectory = async () =>
   await rm(tempDirName, { recursive: true, force: true });
 
-const getCurrentVersion = async (): Promise<string> => {
-  const packageJson = JSON.parse(await readFile('package.json', 'utf-8'));
+const getCurrentVersion = async (): Promise<string | undefined> => {
+  const packageJsonPath = join(process.cwd(), 'package.json');
+  const packageJsonContents = await readFile(packageJsonPath, 'utf-8');
+  const packageJson = JSON.parse(packageJsonContents) as { version?: string };
+
   return packageJson.version;
 };
 

--- a/scripts/update.ts
+++ b/scripts/update.ts
@@ -155,13 +155,11 @@ export const update = async (options: { from?: string; to?: string }) => {
       return;
     }
 
-    const upgradeableVersions = currentVersion
-      ? availableVersions.filter(
-          (v) => compareVersions(v, currentVersion ?? '') > 0
-        )
-      : availableVersions;
+    const upgradeableVersions = availableVersions.filter(
+      (v) => compareVersions(v, fromVersion) > 0
+    );
 
-    const nextVersion = upgradeableVersions[0];
+    const [nextVersion] = upgradeableVersions;
 
     const toVersion =
       options.to || (await selectVersion(upgradeableVersions, nextVersion));

--- a/scripts/update.ts
+++ b/scripts/update.ts
@@ -77,11 +77,12 @@ const getCurrentVersion = async (): Promise<string | undefined> => {
 };
 
 const selectVersion = async (
+  label: string,
   availableVersions: string[],
   initialValue: string | undefined
 ) => {
   const version = await select({
-    message: 'Select a version to update to:',
+    message: `Select a version to update ${label}:`,
     options: availableVersions.map((v) => ({ value: v, label: `v${v}` })),
     initialValue,
     maxItems: 10,
@@ -148,7 +149,8 @@ export const update = async (options: { from?: string; to?: string }) => {
     s1.stop();
 
     const fromVersion =
-      options.from || (await selectVersion(availableVersions, currentVersion));
+      options.from ||
+      (await selectVersion('from', availableVersions, currentVersion));
 
     if (fromVersion === availableVersions[0]) {
       outro('You are already on the latest version!');
@@ -162,7 +164,8 @@ export const update = async (options: { from?: string; to?: string }) => {
     const [nextVersion] = upgradeableVersions;
 
     const toVersion =
-      options.to || (await selectVersion(upgradeableVersions, nextVersion));
+      options.to ||
+      (await selectVersion('to', upgradeableVersions, nextVersion));
 
     const from = `v${fromVersion}`;
     const to = `v${toVersion}`;

--- a/scripts/update.ts
+++ b/scripts/update.ts
@@ -132,21 +132,13 @@ export const update = async (options: { from?: string; to?: string }) => {
     intro("Let's update your next-forge project!");
 
     const cwd = process.cwd();
-    const s1 = spinner();
-
-    s1.start('Getting available versions...');
     const availableVersions = await getAvailableVersions();
-
-    s1.message('Getting current version from package.json...');
     let currentVersion = await getCurrentVersion();
 
     // Ditch the project version if it is not in the available versions
     if (currentVersion && !availableVersions.includes(currentVersion)) {
-      s1.message('Current version is not a valid next-forge version....');
       currentVersion = undefined;
     }
-
-    s1.stop();
 
     const fromVersion =
       options.from ||
@@ -170,26 +162,26 @@ export const update = async (options: { from?: string; to?: string }) => {
     const from = `v${fromVersion}`;
     const to = `v${toVersion}`;
 
-    const s2 = spinner();
+    const s = spinner();
 
-    s2.start(`Preparing to update from ${from} to ${to}...`);
+    s.start(`Preparing to update from ${from} to ${to}...`);
 
-    s2.message('Creating temporary directory...');
+    s.message('Creating temporary directory...');
     await createTemporaryDirectory(tempDirName);
 
-    s2.message('Cloning next-forge...');
+    s.message('Cloning next-forge...');
     await cloneRepository(tempDirName);
 
-    s2.message('Moving into repository...');
+    s.message('Moving into repository...');
     process.chdir(tempDirName);
 
-    s2.message(`Getting files from version ${from}...`);
+    s.message(`Getting files from version ${from}...`);
     const fromFiles = await getFiles(from);
 
-    s2.message(`Getting files from version ${to}...`);
+    s.message(`Getting files from version ${to}...`);
     const toFiles = await getFiles(to);
 
-    s2.message(`Computing diff between versions ${from} and ${to}...`);
+    s.message(`Computing diff between versions ${from} and ${to}...`);
     const diff = await getDiff(
       {
         version: from,
@@ -201,16 +193,16 @@ export const update = async (options: { from?: string; to?: string }) => {
       }
     );
 
-    s2.message('Moving back to original directory...');
+    s.message('Moving back to original directory...');
     process.chdir(cwd);
 
-    s2.message(`Updating ${diff.length} files...`);
+    s.message(`Updating ${diff.length} files...`);
     await updateFiles(diff);
 
-    s2.message('Cleaning up...');
+    s.message('Cleaning up...');
     await deleteTemporaryDirectory();
 
-    s2.stop(`Successfully updated project from ${from} to ${to}!`);
+    s.stop(`Successfully updated project from ${from} to ${to}!`);
 
     outro('Please review and test the changes carefully.');
   } catch (error) {

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -42,6 +42,7 @@ export const getAvailableVersions = async (): Promise<string[]> => {
   const changelog = await readFile('CHANGELOG.md', 'utf-8');
   const versionRegex = /# v(\d+\.\d+\.\d+)/g;
   const matches = [...changelog.matchAll(versionRegex)];
+
   return matches
     .map((match) => match[1])
     .sort((a, b) => {

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,4 +1,5 @@
 import { type ExecSyncOptions, exec as execRaw } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 
@@ -36,3 +37,22 @@ export const tempDirName = 'next-forge-update';
 export const exec = promisify(execRaw);
 
 export const supportedPackageManagers = ['npm', 'yarn', 'bun', 'pnpm'];
+
+export const getAvailableVersions = async (): Promise<string[]> => {
+  const changelog = await readFile('CHANGELOG.md', 'utf-8');
+  const versionRegex = /# v(\d+\.\d+\.\d+)/g;
+  const matches = [...changelog.matchAll(versionRegex)];
+  return matches
+    .map((match) => match[1])
+    .sort((a, b) => {
+      const [aMajor, aMinor, aPatch] = a.split('.').map(Number);
+      const [bMajor, bMinor, bPatch] = b.split('.').map(Number);
+      if (aMajor !== bMajor) {
+        return bMajor - aMajor;
+      }
+      if (aMinor !== bMinor) {
+        return bMinor - aMinor;
+      }
+      return bPatch - aPatch;
+    });
+};


### PR DESCRIPTION
## Description

I was thinking it might be easier for users to be given a list of all the available versions they can update to rather then them looking for which ones are available. Will give devs easier/faster experience so they don't have to search for too long. This gets the current version from the package.json and compares it to the changelog.md file

Was also thinking of a way to add small descriptions on the versions. Kind of an all in one spot but might be too crowded with that much info.

## Related Issues

N/A

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [ ] New and existing tests pass locally with my changes.

## Screenshots (if applicable)
If a user have available versions to update to:
```
┌  Let's update your next-forge project!
│
●  Current version: v3.2.10
│
◆  Select a version to update to:
│  ● v3.2.15
│  ○ v3.2.14
│  ○ v3.2.13
│  ○ v3.2.12
│  ○ v3.2.11
└
```

If a user is already on the latest versionL
```
┌  Let's update your next-forge project!
│
●  Current version: v3.2.15
│
●  You are already on the latest version!
```



## Additional Notes

Let me know what you think!
Love the project & always thinking on ways to improve!