### PR TITLE
fix error: build script in /packages/cms

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "basehub dev",
-    "build": "basehub",
+    "build": "basehub build",
     "analyze": "basehub",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"


### PR DESCRIPTION
## Description

Invalid build script within /packages/cms. Solution: add "build" after "basehub".

## Checklist

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests that prove my fix is effective or my feature works.
- [x] New and existing tests pass locally with my changes.

## Screenshots (_before and after_)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->
![Screenshot 2025-03-19 at 05 19 58](https://github.com/user-attachments/assets/337ba1da-edf3-4a0b-9897-b6f4a97cf750)
![Screenshot 2025-03-19 at 07 41 27](https://github.com/user-attachments/assets/6ed1bf39-cdcb-4404-8d03-27fe857c02c9)