### PR TITLE
fix: metadataBase

### DIFF
--- a/packages/seo/metadata.ts
+++ b/packages/seo/metadata.ts
@@ -26,6 +26,10 @@ export const createMetadata = ({
     title: parsedTitle,
     description,
     applicationName,
+    metadataBase: new URL(
+      // biome-ignore lint/style/noNonNullAssertion: "Using a type assertion as we know for sure that the project will have a URL. Vercel var doesn't include https:// https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_PROJECT_PRODUCTION_URL"
+      `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL!}`
+    ),
     authors: [author],
     creator: author.name,
     formatDetection: {

--- a/packages/seo/metadata.ts
+++ b/packages/seo/metadata.ts
@@ -14,6 +14,8 @@ const author: Metadata['authors'] = {
 };
 const publisher = 'Hayden Bleasel';
 const twitterHandle = '@haydenbleasel';
+const protocol = process.env.NODE_ENV === 'production' ? 'https' : 'http';
+const productionUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL;
 
 export const createMetadata = ({
   title,
@@ -26,10 +28,9 @@ export const createMetadata = ({
     title: parsedTitle,
     description,
     applicationName,
-    metadataBase: new URL(
-      // biome-ignore lint/style/noNonNullAssertion: "Using a type assertion as we know for sure that the project will have a URL. Vercel var doesn't include https:// https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_PROJECT_PRODUCTION_URL"
-      `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL!}`
-    ),
+    metadataBase: productionUrl
+      ? new URL(`${protocol}://${productionUrl}`)
+      : undefined,
     authors: [author],
     creator: author.name,
     formatDetection: {


### PR DESCRIPTION
## Description

Error in the logs when building:
```
 ⚠ metadataBase property in metadata export is not set for resolving social open graph or twitter images, using "https://trimcarbon.com". See https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase
```

I'd also suggest editing robots.ts to use https:// by default as Vercel var doesn't include https:// https://vercel.com/docs/environment-variables/system-environment-variables#VERCEL_PROJECT_PRODUCTION_URL (and thus the logic will always be outputting http). 
