### PR TITLE
fix: language switcher

### DIFF
--- a/apps/web/app/[locale]/components/header/language-switcher.tsx
+++ b/apps/web/app/[locale]/components/header/language-switcher.tsx
@@ -25,8 +25,22 @@ export const LanguageSwitcher = () => {
   const params = useParams();
 
   const switchLanguage = (locale: string) => {
-    // Replace the current locale in the pathname with the new one
-    const newPathname = pathname.replace(`/${params.locale}`, `/${locale}`);
+    const defaultLocale = 'en';
+    let newPathname = pathname;
+
+    // Case 1: If current locale is default and missing from the URL
+    if (
+      !pathname.startsWith(`/${params.locale}`) &&
+      params.locale === defaultLocale
+    ) {
+      // Add the default locale to the beginning to normalize
+      newPathname = `/${params.locale}${pathname}`;
+    }
+
+    // Replace current locale with the selected one
+    newPathname = newPathname.replace(`/${params.locale}`, `/${locale}`);
+    console.log(newPathname);
+
     router.push(newPathname);
   };
 


### PR DESCRIPTION
## Description

Noticed the language switcher was only working from other locales > english or other locales > other locales. 

Because /en wasn't in the pathname, the router was pushing the same url (as there was nothing to replace).

See recording:
![CleanShot 2025-05-09 at 16 06 51](https://github.com/user-attachments/assets/f9961f07-fd60-4c98-b1e9-03192a9b563e)

See after change (recorded on my own project for simplicity):
![CleanShot 2025-05-09 at 16 10 08](https://github.com/user-attachments/assets/a0cd98bb-527d-41da-acdf-8136c34a8b29)


