### PR TITLE
fix: posthog host

### DIFF
--- a/packages/analytics/posthog/client.tsx
+++ b/packages/analytics/posthog/client.tsx
@@ -7,23 +7,23 @@ import { useEffect } from 'react';
 import { keys } from '../keys';
 
 type PostHogProviderProps = {
-  readonly children: ReactNode;
+	readonly children: ReactNode;
 };
 
 export const PostHogProvider = (
-  properties: Omit<PostHogProviderProps, 'client'>
+	properties: Omit<PostHogProviderProps, 'client'>
 ) => {
-  useEffect(() => {
-    posthog.init(keys().NEXT_PUBLIC_POSTHOG_KEY, {
-      api_host: '/ingest',
-      ui_host: keys().NEXT_PUBLIC_POSTHOG_HOST,
-      person_profiles: 'identified_only',
-      capture_pageview: false, // Disable automatic pageview capture, as we capture manually
-      capture_pageleave: true, // Overrides the `capture_pageview` setting
-    }) as PostHog;
-  }, []);
+	useEffect(() => {
+		posthog.init(keys().NEXT_PUBLIC_POSTHOG_KEY, {
+			api_host: keys().NEXT_PUBLIC_POSTHOG_HOST,
+			ui_host: keys().NEXT_PUBLIC_POSTHOG_HOST,
+			person_profiles: 'identified_only',
+			capture_pageview: false, // Disable automatic pageview capture, as we capture manually
+			capture_pageleave: true, // Overrides the `capture_pageview` setting
+		}) as PostHog;
+	}, []);
 
-  return <PostHogProviderRaw client={posthog} {...properties} />;
+	return <PostHogProviderRaw client={posthog} {...properties} />;
 };
 
 export { usePostHog as useAnalytics } from 'posthog-js/react';


### PR DESCRIPTION
## Description

I wasn't able to get Posthog to see pageviews until I made that change (based on their docs):
<img width="942" alt="CleanShot 2025-05-19 at 18 15 31@2x" src="https://github.com/user-attachments/assets/e3a3b564-ec3d-4232-9980-0d27c6e58304" />

<img width="779" alt="CleanShot 2025-05-19 at 18 16 11@2x" src="https://github.com/user-attachments/assets/708fef08-3083-4f35-83e2-05596ceffc0c" />

Leaving as draft and letting @haydenbleasel decide if that's worth merging